### PR TITLE
Fix Python error when the profile is outside of layer bounds

### DIFF
--- a/tools/plottingtool.py
+++ b/tools/plottingtool.py
@@ -195,7 +195,7 @@ class PlottingTool:
 			minimumValue = 1000000000
 			maximumValue = -1000000000
 			for i in range(0,len(profiles)):
-				if profiles[i]["layer"] != None and len(profiles[i]["z"]) > 0:
+				if profiles[i]["layer"] != None and len([z for z in profiles[i]["z"] if z is not None]) > 0:
 					if self.findMin(profiles, i,scale) < minimumValue:
 						minimumValue = self.findMin(profiles, i,scale)
 					if self.findMax(profiles, i,scale) > maximumValue:


### PR DESCRIPTION
Currently if the selectd profile is completely out of bounds, the following error will pop up (because profile[nr]["z] is full of None values):

Traceback (most recent call last):
  File "/home/martin/.qgis2/python/plugins/profiletool/profileplugin.py", line 201, in doubleClicked
    self.doprofile.calculateProfil(self.pointstoDraw,self.mdl, self.plotlibrary)
  File "/home/martin/.qgis2/python/plugins/profiletool/tools/doprofile.py", line 80, in calculateProfil
    PlottingTool().reScalePlot(self.dockwidget.scaleSlider.value(), self.dockwidget, self.profiles, library)
  File "/home/martin/.qgis2/python/plugins/profiletool/tools/plottingtool.py", line 199, in reScalePlot
    if self.findMin(profiles, i,scale)   File "/home/martin/.qgis2/python/plugins/profiletool/tools/plottingtool.py", line 176, in findMin
    minVal = min( z for z in profiles[nr]["z"] if z is not None )
ValueError: min() arg is an empty sequence
