### PR TITLE
Add copy coordinates button to table view

### DIFF
--- a/tools/dataReaderTool.py
+++ b/tools/dataReaderTool.py
@@ -57,6 +57,8 @@ class DataReaderTool:
 		#Get the values on the lines
 		l = []
 		z = []
+		x = []
+		y = []
 		lbefore = 0
 		for i in range(0,len(self.pointstoDraw)-2):  # work for each segment of polyline
 
@@ -132,6 +134,8 @@ class DataReaderTool:
 				#print "Null cell value catched as zero!"  # For none values, profile height = 0. It's not elegant...
 
 				z += [attr]
+				x += [xC]
+				y += [yC]
 				temp = n
 				if n % stepp == 0:
 					progress += "|"
@@ -141,6 +145,8 @@ class DataReaderTool:
 		#filling the main data dictionary "profiles"
 		self.profiles["l"] = l
 		self.profiles["z"] = z
+		self.profiles["x"] = x
+		self.profiles["y"] = y
 		self.iface.mainWindow().statusBar().showMessage("")
 
 		return self.profiles

--- a/tools/doprofile.py
+++ b/tools/doprofile.py
@@ -149,6 +149,19 @@ class DoProfile(QWidget):
 			self.verticalLayout[i].addWidget(self.pushButton[i])
 			self.VLayout.addWidget(self.groupBox[i])
 			QObject.connect(self.pushButton[i], SIGNAL("clicked()"), self.copyTable)
+# add another button
+			#the copy to clipboard button
+			self.pushButton.append( QPushButton(self.groupBox[i]) )
+			sizePolicy = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+			sizePolicy.setHorizontalStretch(0)
+			sizePolicy.setVerticalStretch(0)
+			sizePolicy.setHeightForWidth(self.pushButton[i+1].sizePolicy().hasHeightForWidth())
+			self.pushButton[i+1].setSizePolicy(sizePolicy)
+			self.pushButton[i+1].setText(QApplication.translate("GroupBox", "Copy coords to clipboard", None, QApplication.UnicodeUTF8))
+			self.pushButton[i+1].setObjectName(str(i))
+			self.verticalLayout[i].addWidget(self.pushButton[i+1])
+			self.VLayout.addWidget(self.groupBox[i])
+			QObject.connect(self.pushButton[i+1], SIGNAL("clicked()"), self.copyCoords)
 
 
 	def copyTable(self):							#Writing the table to clipboard in excel form
@@ -157,6 +170,14 @@ class DoProfile(QWidget):
 		text = ""
 		for i in range( len(self.profiles[nr]["l"]) ):
 			text += str(self.profiles[nr]["l"][i]) + "\t" + str(self.profiles[nr]["z"][i]) + "\n"
+		self.clipboard.setText(text)
+
+	def copyCoords(self):							#Writing the table to clipboard in excel form
+		nr = int( self.sender().objectName() )
+		self.clipboard = QApplication.clipboard()
+		text = ""
+		for i in range( len(self.profiles[nr]["l"]) ):
+			text += str(self.profiles[nr]["l"][i]) + "\t" + str(self.profiles[nr]["x"][i]) + "\t" + str(self.profiles[nr]["y"][i]) + "\n"
 		self.clipboard.setText(text)
 
 

--- a/tools/doprofile.py
+++ b/tools/doprofile.py
@@ -149,19 +149,19 @@ class DoProfile(QWidget):
 			self.verticalLayout[i].addWidget(self.pushButton[i])
 			self.VLayout.addWidget(self.groupBox[i])
 			QObject.connect(self.pushButton[i], SIGNAL("clicked()"), self.copyTable)
-# add another button
-			#the copy to clipboard button
-			self.pushButton.append( QPushButton(self.groupBox[i]) )
-			sizePolicy = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
-			sizePolicy.setHorizontalStretch(0)
-			sizePolicy.setVerticalStretch(0)
-			sizePolicy.setHeightForWidth(self.pushButton[i+1].sizePolicy().hasHeightForWidth())
-			self.pushButton[i+1].setSizePolicy(sizePolicy)
-			self.pushButton[i+1].setText(QApplication.translate("GroupBox", "Copy coords to clipboard", None, QApplication.UnicodeUTF8))
-			self.pushButton[i+1].setObjectName(str(i))
-			self.verticalLayout[i].addWidget(self.pushButton[i+1])
-			self.VLayout.addWidget(self.groupBox[i])
-			QObject.connect(self.pushButton[i+1], SIGNAL("clicked()"), self.copyCoords)
+
+        # add coordinate button after all layers shown
+        self.pushButton.append(QPushButton(self.groupBox[i]))
+		sizePolicy = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+		sizePolicy.setHorizontalStretch(0)
+		sizePolicy.setVerticalStretch(0)
+		sizePolicy.setHeightForWidth(self.pushButton[i+1].sizePolicy().hasHeightForWidth())
+		self.pushButton[i+1].setSizePolicy(sizePolicy)
+		self.pushButton[i+1].setText(QApplication.translate("GroupBox", "Copy coords to clipboard", None, QApplication.UnicodeUTF8))
+		self.pushButton[i+1].setObjectName(str(i))
+		self.verticalLayout[i].addWidget(self.pushButton[i+1])
+		self.VLayout.addWidget(self.groupBox[i])
+		QObject.connect(self.pushButton[i+1], SIGNAL("clicked()"), self.copyCoords)
 
 
 	def copyTable(self):							#Writing the table to clipboard in excel form


### PR DESCRIPTION
The changes add a copy coordinates button to the table view which allows the coordinates of the profile sample points to be used in external calculations